### PR TITLE
verified compatibility with the node v0.10.23 release. bumped version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "iptrie"
 , "description" : "IP tries (prefix tree)"
 , "keywords" : [ "iptrie", "blocklist", "IP", "acl" ]
-, "version" : "0.0.3"
+, "version" : "0.0.4"
 , "author" : { "name" : "Theo Schlossnagle" }
 , "directories": { "lib": "." }
 , "repository" :
@@ -12,7 +12,7 @@
   { "url" : "http://github.com/postwait/node-iptrie/issues"
   }
 , "main" : "iptrie"
-, "engines" : { "node" : "0.2 || 0.4 || 0.5 || 0.6 || 0.8" }
+, "engines" : { "node" : "0.2 || 0.4 || 0.5 || 0.6 || 0.8 || 0.10" }
 , "licenses" :
   [ { "type" : "BSD" } ]
 }


### PR DESCRIPTION
This pull resolves an npm warning because of the supported engines in the package.json.

npm WARN engine iptrie@0.0.3: wanted: {"node":"0.2 || 0.4 || 0.5 || 0.6 || 0.8"} (current: {"node":"v0.10.23","npm":"1.3.17"})

I've tested it on v0.10.22, v0.10.23 and everything works as expected. 
