### PR TITLE
potential crash in route_del ?

### DIFF
--- a/src/btrie.cc
+++ b/src/btrie.cc
@@ -126,10 +126,13 @@ del_route(btrie *tree, uint32_t *key, unsigned char prefix_len,
       node->incidental = 1;
       if(node->bit[0] == NULL || node->bit[1] == NULL) {
         /* collapse (even if both are null) */
-        parent->bit[BIT_AT(key, parent->prefix_len+1)] =
-          node->bit[ (node->bit[0] == NULL) ? 1 : 0 ];
+        if (parent)
+          parent->bit[BIT_AT(key, parent->prefix_len+1)] =
+            node->bit[ (node->bit[0] == NULL) ? 1 : 0 ];
         node->bit[0] = node->bit[1] = NULL;
         drop_node(node, f);
+        if (node == *tree)
+          *tree = NULL;
       }
       return 1;
     }


### PR DESCRIPTION
perhaps not applicable as it could very well be the way I was using it, but in my tester I can consistently crash it if I insert and then delete a single /32 ip.

This PR checks parent pointer in del_route to prevent NULL dereference. Also, NULLs the tree pointer if node being removed is last, in drop_node.
